### PR TITLE
solve issue of low contrast

### DIFF
--- a/res/layout/main_activity.xml
+++ b/res/layout/main_activity.xml
@@ -42,7 +42,7 @@
             android:text="@string/empty_whitelist_message"
             android:textAlignment="center"
             android:textAppearance="?android:attr/textAppearanceMedium"
-            android:textColor="@android:color/darker_gray" />
+            android:textColor="#646464" />
 
         <RelativeLayout
             android:id="@+id/whitelist_layout"


### PR DESCRIPTION
The original text color of the component is '#AAAAAA', and the contrast between the text color ('#BEBEBE') and the background color ('#EFEFEF') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#646464') are as follows:
![image](https://user-images.githubusercontent.com/101503193/158527899-c1d09337-a259-464e-826f-463ab0c91c00.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.